### PR TITLE
Add distributionManagement for artifact storage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,17 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<java.version>1.8</java.version>
+		<nexusproxy>https://nexus.edgexfoundry.org</nexusproxy>
+		<repobasepath>content/repositories</repobasepath>
 	</properties>
+
+	<distributionManagement>
+		<snapshotRepository>
+			<id>snapshots</id>
+			<name>EdgeX Snapshot Repository</name>
+			<url>${nexusproxy}/${repobasepath}/snapshots</url>
+		</snapshotRepository>
+	</distributionManagement>
 
 	<dependencies>
 		<dependency>


### PR DESCRIPTION
To store the built SNAPSHOTS of artifacts a distributionManagement
section is required in the pom.xml file.

Signed-off-by: Andrew Grimberg <agrimberg@linuxfoundation.org>